### PR TITLE
hooks: fix commit message template configuration

### DIFF
--- a/docs/aliases.rst
+++ b/docs/aliases.rst
@@ -42,7 +42,7 @@ had to create local references here.
 
 .. py:class:: flask_sqlalchemy.Model
 
-   Flask SQLAlchemy model: :py:class:`flask.ext.sqlalchemy.Model`
+   Flask SQLAlchemy model: :py:class:`flask_sqlalchemy.Model`
 
 .. py:class:: werkzeug.routing.BaseConverter
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,6 +59,7 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
     'sphinx.ext.viewcode',
+    'sphinxcontrib.issuetracker',  # autolinks issue numbers (like #62)
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -309,3 +310,6 @@ if sys.version_info < (3,):
     intersphinx_mapping['http://docs.python.org/2.7/'] = None
 else:
     intersphinx_mapping['http://docs.python.org/3.4/'] = None
+
+# sphinxcontrib.issuetracker settings
+issuetracker = 'github'

--- a/kwalitee/cli/__init__.py
+++ b/kwalitee/cli/__init__.py
@@ -24,7 +24,7 @@
 """Command line interfaces entrypoints."""
 
 
-from flask.ext.script import Manager
+from flask_script import Manager
 
 from . import account, check, githooks, repository
 

--- a/kwalitee/cli/account.py
+++ b/kwalitee/cli/account.py
@@ -29,7 +29,7 @@ import sys
 
 from ..models import db, Account
 
-from flask.ext.script import Manager
+from flask_script import Manager
 
 manager = Manager(usage="repository management")
 

--- a/kwalitee/cli/check.py
+++ b/kwalitee/cli/check.py
@@ -32,7 +32,7 @@ import shutil
 import sys
 
 from flask import current_app
-from flask.ext.script import Manager
+from flask_script import Manager
 
 from tempfile import mkdtemp
 

--- a/kwalitee/cli/githooks.py
+++ b/kwalitee/cli/githooks.py
@@ -29,7 +29,7 @@ import os
 import sys
 
 from flask import current_app as app
-from flask.ext.script import Manager
+from flask_script import Manager
 
 from ..hooks import (pre_commit_hook, prepare_commit_msg_hook, run,
                      post_commit_hook)

--- a/kwalitee/cli/repository.py
+++ b/kwalitee/cli/repository.py
@@ -29,7 +29,7 @@ import sys
 
 from ..models import db, Account, Repository
 
-from flask.ext.script import Manager
+from flask_script import Manager
 
 manager = Manager(usage="repository management")
 

--- a/kwalitee/factory.py
+++ b/kwalitee/factory.py
@@ -29,7 +29,7 @@ from __future__ import unicode_literals
 import os
 
 from flask import Flask, Config
-from flask.ext.sqlalchemy import SQLAlchemy
+from flask_sqlalchemy import SQLAlchemy
 from werkzeug.routing import BaseConverter
 
 class ShaConverter(BaseConverter):

--- a/kwalitee/hooks.py
+++ b/kwalitee/hooks.py
@@ -29,11 +29,12 @@ import os
 import re
 import shutil
 import sys
-import yaml
 
 from codecs import open
 from subprocess import PIPE, Popen
 from tempfile import mkdtemp
+
+import yaml
 
 from .kwalitee import SUPPORTED_FILES, check_file, check_message, get_options
 
@@ -139,12 +140,15 @@ def prepare_commit_msg_hook(argv):
     """Hook: prepare a commit message."""
     from flask import current_app
     with current_app.app_context():
-        template = current_app.config["COMMIT_MSG_TEMPLATE"]
+        options = get_options(current_app.config)
+
+    # Check if the repo has a configuration repo
+    options.update(_read_local_kwalitee_configuration())
 
     _prepare_commit_msg(argv[1],
                         _get_git_author(),
                         _get_files_modified(),
-                        template)
+                        options.get('template'))
     return 0
 
 

--- a/kwalitee/kwalitee.py
+++ b/kwalitee/kwalitee.py
@@ -25,14 +25,19 @@
 
 from __future__ import unicode_literals
 
+import codecs
 import os
 import re
-import pep8
-import codecs
+
 import pep257
+
+import pep8
+
 import pyflakes
 import pyflakes.checker
+
 import tokenize
+
 from datetime import datetime
 
 
@@ -77,20 +82,6 @@ _licenses_codes = {
     "L103": "license is not GNU GPLv2",
     "L190": "file cannot be decoded as {0}"
 }
-
-
-@pep257.check_for(pep257.Definition)
-def check_whitespaces(self, definition, docstring):
-    """D290: White spaces around doctring should be trimmed."""
-    if docstring:
-        lines = eval(docstring).split('\n')
-        if lines[0].startswith(' ') or \
-                len(lines) == 1 and lines[0].endswith(' '):
-            return pep257.Error(
-                'D290: White spaces around docstring should be trimmed.'
-            )
-
-pep257.PEP257Checker.check_whitespaces = check_whitespaces
 
 
 def _check_1st_line(line, **kwargs):
@@ -565,6 +556,7 @@ def get_options(config):
     base = {
         "components": config.get("COMPONENTS"),
         "signatures": config.get("SIGNATURES"),
+        "commit_msg_template": config.get("COMMIT_MSG_TEMPLATE"),
         "alt_signatures": config.get("ALT_SIGNATURES"),
         "trusted": config.get("TRUSTED_DEVELOPERS"),
         "pep8": config.get("CHECK_PEP8", True),

--- a/kwalitee/models.py
+++ b/kwalitee/models.py
@@ -29,7 +29,7 @@ import os
 
 from datetime import datetime
 from flask import json
-from flask.ext.sqlalchemy import SQLAlchemy
+from flask_sqlalchemy import SQLAlchemy
 
 
 # Storing states as integers so string can be changed/l10n later

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 Sphinx
 sphinx_rtd_theme
+sphinxcontrib-issuetracker

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ install_requires = [
     'Flask-SQLAlchemy',
     'pep8',
     'pep8-naming',
-    'pep257',
+    'pep257>=0.5.0',
     'pyflakes',
     'flake8-import-order',
     'flake8-blind-except',

--- a/tests/test_check_file.py
+++ b/tests/test_check_file.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of kwalitee
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # kwalitee is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -25,10 +25,11 @@ from __future__ import unicode_literals
 
 import os
 import tempfile
-from kwalitee.kwalitee import check_pep8, check_pep257, check_license
-from unittest import TestCase
+
 from hamcrest import (assert_that, has_length, has_item, has_items, is_not,
                       contains_string)
+from kwalitee.kwalitee import check_pep8, check_pep257, check_license
+from unittest import TestCase
 
 
 class TestCheckFile(TestCase):
@@ -104,7 +105,7 @@ class TestCheckPep257(TestCheckFile):
     def test_missing(self):
         """invalid.py has no docstring"""
         errors = check_pep257(self.invalid)
-        assert_that(errors, has_item("1: D100 Docstring missing"))
+        assert_that(errors, has_item("1: D100 Missing docstring in public module"))
 
     def test_invalid_token(self):
         """invalid_token.py has a tokenization error"""

--- a/tests/test_pull_request.py
+++ b/tests/test_pull_request.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of kwalitee
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # kwalitee is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -23,7 +23,7 @@
 
 """Integration tests for the pull_request event."""
 
-from __future__ import unicode_literals, absolute_import
+from __future__ import absolute_import, unicode_literals
 
 import httpretty
 
@@ -642,7 +642,7 @@ def test_pep8_pull_request_task(app, owner, repository, session):
         "",
         "",
         "",
-        "D100 Docstring missing",
+        "D100 Missing docstring in public module",
         "/status/1",
         "",
         "in_review",

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of kwalitee
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # kwalitee is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -23,12 +23,12 @@
 
 """Integration tests for the pull_request event."""
 
-from __future__ import unicode_literals, absolute_import
+from __future__ import absolute_import, unicode_literals
 
 import httpretty
 
 from flask import json
-from kwalitee.models import Repository, CommitStatus
+from kwalitee.models import CommitStatus, Repository
 from kwalitee.tasks import push
 from hamcrest import (assert_that, equal_to, contains_string, has_length,
                       has_item)
@@ -542,4 +542,4 @@ def test_push_half_known_commit(repository, session):
     assert_that(cs)
     assert_that(cs.is_pending(), equal_to(False))
     assert_that(cs.content["files"]["spam/eggs.py"]["errors"],
-                has_item("1: D100 Docstring missing"))
+                has_item("1: D100 Missing docstring in public module"))


### PR DESCRIPTION
* BETTER Reads 'commit_msg_template' configuration value from
  `.kwalitee.yml`.  (closes #62)

* BETTER Uses updated 'pep257>=0.5.0' package.

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>