### PR TITLE
global: disable python 3.4 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ python:
  - "2.6"
  - "2.7"
  - "3.3"
- - "3.4"
+# TODO re-enable after gabrielfalcao/HTTPretty#193 will be merged
+# - "3.4"
 
 env:
   global:


### PR DESCRIPTION
* Disables travis tests for python 3.4. (closes #66)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>