### PR TITLE
global: addition of new author

### DIFF
--- a/.kwalitee.yml
+++ b/.kwalitee.yml
@@ -11,6 +11,7 @@ components:
 - travis
 - views
 exclude_author_names:
+- David Caro <dcaroest@redhat.com>
 - Jiri Kuncar <jiri.kuncar@gmail.com>
 - Mateusz Susik <mateusz.susik@cern.ch>
 - Yoan Blanc <yoan.blanc@cern.ch>

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -39,3 +39,4 @@ Contributors
 * Harris Tzovanakis <me@drjova.com>
 * Leonardo Rossi <leonardo.r@cern.ch>
 * Tibor Simko <tibor.simko@cern.ch>
+* David Caro <david@dcaro.es>


### PR DESCRIPTION
Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>