### PR TITLE
global: allow utf8 in commit message

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -40,3 +40,4 @@ Contributors
 * Leonardo Rossi <leonardo.r@cern.ch>
 * Tibor Simko <tibor.simko@cern.ch>
 * David Caro <david@dcaro.es>
+* Ivan Masár <helix84@centrum.sk>

--- a/kwalitee/cli/check.py
+++ b/kwalitee/cli/check.py
@@ -163,7 +163,7 @@ def message(obj, commit='HEAD', skip_merge_commits=False):
         errors.append(reset)
 
         click.echo(template.format(commit=commit,
-                                   message=message,
+                                   message=message.encode('utf-8'),
                                    errors='\n'.join(errors)))
 
     if min(count, 1):
@@ -271,7 +271,7 @@ def files(obj, commit='HEAD', skip_merge_commits=False):
             errors = no_errors
 
         click.echo(template.format(commit=commit,
-                                   message=message,
+                                   message=message.encode('utf-8'),
                                    errors='\n'.join(errors)))
 
     if min(count, 1):

--- a/tests/cli/test_check.py
+++ b/tests/cli/test_check.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of kwalitee
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2016 CERN.
 #
 # kwalitee is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -81,3 +81,14 @@ def test_check_branch_wrong_side(capsys, git):
     result = runner.invoke(check, ['-r', git, 'message', 'testbranch..master'])
     assert_that(result.exit_code, equal_to(0))
     assert_that(result.output.split("\n"), equal_to([""]))
+
+
+@skip
+def test_check_branch_utf8(capsys, git):
+    """Test correct output of 'kwalitee check message' on UTF8 in commit
+    message, signature and file name. These are in the utf8 branch in the
+    fixture"""
+    runner = CliRunner()
+    result = runner.invoke(check, ['-r', git, 'message', 'master..utf8'])
+    assert_that(result.exit_code, equal_to(0))
+    assert_that(result.output.split("\n"), has_item("Everything is OK."))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of kwalitee
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2016 CERN.
 #
 # kwalitee is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -23,7 +23,6 @@
 
 """Configuration for py.test."""
 
-import os
 import shutil
 import subprocess
 import tempfile
@@ -46,6 +45,12 @@ def git(request):
                 ("touch", "TODO"),
                 ("git", "add", "TODO"),
                 ("git", "commit", "-m", "global: kikoo\n\nBy: bob <a@b.org>"),
+                ("git", "checkout", "master"),
+                ("git", "checkout", "-b", "utf8"),
+                ("touch", "líščí.txt"),
+                ("git", "add", "líščí.txt"),
+                ("git", "commit", "-m", "global: líščí\n\n"
+                    "* Příliš žluťoučký kůň úpěl ďábelské ódy.\n\nSigned-off-by: Motörhead <a@b.org>"),
                 ("git", "checkout", "master"))
 
     for command in commands:

--- a/tests/test_check_message.py
+++ b/tests/test_check_message.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of kwalitee
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # kwalitee is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -216,3 +216,10 @@ class TestCheckMessage(TestCase):
             "19: M123 no dot at the end of the sentence",
             "24: M123 no dot at the end of the sentence",
         ))
+
+    def test_allow_utf8_in_message(self):
+        errors = check_message("search: hello\r\n\r\n"
+                               "* Líščí.\r\n\r\n"
+                               "Signed-off-by: a a <john.doe@example.org>",
+                               **self.options)
+        assert_that(errors, has_length(0))


### PR DESCRIPTION
 * E.g. the Signed-off-by below contains diacritics and will pass
   "kwalitee check message" after this commit.

Signed-off-by: Ivan Masár <helix84@centrum.sk>