### PR TITLE
docs: MAINTAINERS file and LGTM configuration

### DIFF
--- a/.lgtm
+++ b/.lgtm
@@ -1,0 +1,3 @@
+approvals = 1
+pattern = "(?i)LGTM"
+self_approval_off = true

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,2 @@
+Jiri Kuncar <jiri.kuncar@cern.ch> (@jirikuncar)
+Tibor Simko <tibor.simko@cern.ch> (@tiborsimko)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -33,6 +33,7 @@ include .editorconfig
 include .tx/config
 include Dockerfile
 include LICENSE
+include MAINTAINERS
 include Procfile
 include docs/*.rst docs/*.py
 include requirements*.txt

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -26,7 +26,7 @@
 
 pydocstyle kwalitee && \
 isort -rc -c -df **/*.py && \
-check-manifest --ignore ".travis-*" && \
+check-manifest --ignore ".travis-*",".lgtm" && \
 sphinx-build -qnNW docs docs/_build/html && \
 python setup.py test && \
 sphinx-build -qnNW -b doctest docs docs/_build/doctest


### PR DESCRIPTION
* Adds the MAINTAINERS file and the initial LGTM configuration.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>